### PR TITLE
Fixed Parse error that occured when searching for particular tasks

### DIFF
--- a/app/src/main/java/com/example/peerrequest/adapters/SearchAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/SearchAdapter.java
@@ -2,6 +2,7 @@ package com.example.peerrequest.adapters;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,14 +13,18 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.peerrequest.R;
+import com.example.peerrequest.Utilities;
 import com.example.peerrequest.activities.TaskDetailActivity;
 import com.example.peerrequest.models.Task;
+import com.example.peerrequest.models.User;
+import com.parse.ParseException;
 
 import org.parceler.Parcels;
 
 import java.util.List;
 
 public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchViewHolder> {
+    private static final String LOG = "SearchAdapter";
     private final List<Task> tasks;
 
     public SearchAdapter(Context context, List<Task> tasks) {
@@ -63,10 +68,12 @@ public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchView
         }
 
         public void bind(Task task) {
-            username.setText(task.getUser().getUsername());
+            User user = task.getUser();
+            Utilities.roundedImage(itemView.getContext(), user.getProfilePicture().getUrl(), profilePicture, 70);
+            username.setText(user.getUsername());
             taskTitle.setText(task.getTaskTitle());
             taskDescription.setText(task.getDescription());
-            time.setText(task.getCreatedAt().toString());
+            time.setText(Utilities.getSimpleTime(task.getCreatedAt()));
         }
 
         @Override

--- a/app/src/main/java/com/example/peerrequest/fragments/SearchFragment.java
+++ b/app/src/main/java/com/example/peerrequest/fragments/SearchFragment.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class SearchFragment extends Fragment {
     protected SearchAdapter searchAdapter;
-    private final int limit = 10;
+    private final int limit = 30;
     public String querySearch;
     public EditText search;
     public Button searchButton;
@@ -55,16 +55,18 @@ public class SearchFragment extends Fragment {
 
     private void queryTasks(String querySearch) {
         ParseQuery<Task> query = ParseQuery.getQuery(Task.class);
-        query.whereEqualTo(Task.KEY_REQUESTS_TITLE, querySearch);
+        query.whereContains(Task.KEY_REQUESTS_TITLE, querySearch);
+        query.include(Task.KEY_USER);
         query.setLimit(limit);
         query.findInBackground(new FindCallback<Task>() {
             @Override
             public void done(List<Task> tasks, ParseException e) {
                 if (e != null) {
-                    Log.e(TAG, ERROR, e);
+                    Log.e(TAG, ERROR + e.getMessage(), e);
                 } else {
                     allTasks.addAll(tasks);
                     searchAdapter.notifyDataSetChanged();
+
                 }
             }
         });


### PR DESCRIPTION
I made minor changes to fix the search function in the app. I began implementing this late last week after I had completed the milestones required for that week. During the implementation, I kept coming across Parse Issues. It just hit me that this mightve been because I tried to get the User off of the task query without including task.KEY_USER and this seemed to fix the problem.

-I also just realized implementing a completed button in the chat screen isn't the most conventional thing to do so I might revise that next while I figure out how I'd limit a chat to just two users

![search_feature](https://user-images.githubusercontent.com/90366540/177952210-694803fd-3d56-4831-8d0f-9d7d8c0bbc07.png)

