### PR TITLE
Upload picture at signup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <queries>
-
         <!-- Camera -->
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/app/src/main/java/com/example/peerrequest/activities/SignUpActivity.java
+++ b/app/src/main/java/com/example/peerrequest/activities/SignUpActivity.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import com.example.peerrequest.R;
 import com.example.peerrequest.models.User;
+import com.parse.Parse;
 import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.SaveCallback;
@@ -40,6 +41,11 @@ public class SignUpActivity extends AppCompatActivity {
     ImageView signUpProfilePicture;
     private String TAG = "SignUpActivity";
     public ParseFile file;
+    public final String APP_TAG = "MyCustomApp";
+    public final static int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 1034;
+    public String photoFileName = "photo.jpg";
+    File photoFile;
+    private String fileName = "photo.jpg";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,7 +56,6 @@ public class SignUpActivity extends AppCompatActivity {
         btnSubmit = findViewById(R.id.btnSubmit);
         signUpProfilePicture = findViewById(R.id.signUpProfilePicture);
         uploadProfilePictureBtn = findViewById(R.id.imageButton);
-
         btnSubmit.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -58,31 +63,96 @@ public class SignUpActivity extends AppCompatActivity {
 
             }
         });
+        
+        uploadProfilePictureBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                uploadProfilePicture();
+            }
+        });
 
 
     }
 
+    private void uploadProfilePicture() {
+        launchCamera();
+    }
+
+    private void launchCamera() {
+        // create Intent to take a picture and return control to the calling application
+        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        // Create a File reference for future access
+        photoFile = getPhotoFileUri(photoFileName);
+        // wrap File object into a content provider
+        Uri fileProvider = FileProvider.getUriForFile(SignUpActivity.this, "com.codepath.fileprovider", photoFile);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, fileProvider);
+        if (intent.resolveActivity(getPackageManager()) != null) {
+            // Start the image capture intent to take photo
+            startActivityForResult(intent, CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE);
+        }
+    }
+
     private void saveUserProfile() {
         User user = new User();
-        //getting text from editText
+        ParseFile photo = new ParseFile(photoFile);
         String username = signUpUsername.getText().toString();
         String password = signUpPassword.getText().toString();
         //setting the username and password to username and password inputted by user
         user.setUsername(username);
         user.setPassword(password);
-        // Invoking signUpInBackground
         user.signUpInBackground(new SignUpCallback() {
             @Override
             public void done(ParseException e) {
-                if (e == null) {
-                    goMainActivity();
-                } else {
-                    Toast.makeText(SignUpActivity.this, "Something went wrong: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                    Log.e(TAG, e.getMessage());
+                if(e== null){
+//                    goMainActivity();
+                    saveUserProfilePictureInBackground(photo, user);
+                }
+                else{
+                    Toast.makeText(SignUpActivity.this, ""+ e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
             }
         });
+//        user.setProfilePicture(photo);
 
+    }
+
+    private void saveUserProfilePictureInBackground(ParseFile photo, User user) {
+        photo.saveInBackground(new SaveCallback() {
+            @Override
+            public void done(ParseException e) {
+                user.setProfilePicture(photo);
+                goMainActivity();
+            }
+        });
+    }
+
+    private File getPhotoFileUri(String photoFileName) {
+        // Get safe storage directory for photos
+        // Use `getExternalFilesDir` on Context to access package-specific directories.
+        // This way, we don't need to request external read/write runtime permissions.
+        File mediaStorageDir = new File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), TAG);
+        // Create the storage directory if it does not exist
+        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()){
+            Log.d(TAG, "failed to create directory");
+        }
+        // Return the file target for the photo based on filename
+        return (new File(mediaStorageDir.getPath() + File.separator + fileName));
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE) {
+            if (resultCode == RESULT_OK) {
+                // by this point we have the camera photo on disk
+                Bitmap takenImage = BitmapFactory.decodeFile(photoFile.getAbsolutePath());
+                // RESIZE BITMAP
+                // Load the taken image into a preview
+                signUpProfilePicture.setImageBitmap(takenImage);
+            } else { // Result was a failure
+                Toast.makeText(this, "Picture wasn't taken!", Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 
     private void goMainActivity() {

--- a/app/src/main/java/com/example/peerrequest/activities/SignUpActivity.java
+++ b/app/src/main/java/com/example/peerrequest/activities/SignUpActivity.java
@@ -40,8 +40,6 @@ public class SignUpActivity extends AppCompatActivity {
     ImageButton uploadProfilePictureBtn;
     ImageView signUpProfilePicture;
     private String TAG = "SignUpActivity";
-    public ParseFile file;
-    public final String APP_TAG = "MyCustomApp";
     public final static int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 1034;
     public String photoFileName = "photo.jpg";
     File photoFile;
@@ -63,7 +61,7 @@ public class SignUpActivity extends AppCompatActivity {
 
             }
         });
-        
+
         uploadProfilePictureBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -103,16 +101,13 @@ public class SignUpActivity extends AppCompatActivity {
         user.signUpInBackground(new SignUpCallback() {
             @Override
             public void done(ParseException e) {
-                if(e== null){
-//                    goMainActivity();
+                if (e == null) {
                     saveUserProfilePictureInBackground(photo, user);
-                }
-                else{
-                    Toast.makeText(SignUpActivity.this, ""+ e.getMessage(), Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(SignUpActivity.this, "" + e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
             }
         });
-//        user.setProfilePicture(photo);
 
     }
 
@@ -129,10 +124,9 @@ public class SignUpActivity extends AppCompatActivity {
     private File getPhotoFileUri(String photoFileName) {
         // Get safe storage directory for photos
         // Use `getExternalFilesDir` on Context to access package-specific directories.
-        // This way, we don't need to request external read/write runtime permissions.
         File mediaStorageDir = new File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), TAG);
         // Create the storage directory if it does not exist
-        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()){
+        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()) {
             Log.d(TAG, "failed to create directory");
         }
         // Return the file target for the photo based on filename


### PR DESCRIPTION
Implemented the option to open the camera, take a picture and upload that picture at sign up. This will allow a user to be able to sign up with a photo

Problems faced with this:
Apparently it takes a longer time to save a photo to the parse database than it takes to register/sign up a new user. Therefore trying to do the two simultaneously either produces a user with no image, or a ParseFile error. I then experimented with callbacks and realized the best way to go about this would be to sign the user up, and then save the photo in the SignUp callback. In the save callback, I then set the photo to be the User's profile photo before the app is navigated to the main activity. Therefore by the time the User class is queried in the main activity, the photo would've already been saved and set to the Current user.

I do realize though that when I upload a picture from the camera directly, it isn't displayed properly(in terms of size) and so I might have to come back to this.

https://user-images.githubusercontent.com/90366540/178199837-702c1f4c-d085-470b-bf93-b6d4481a08c2.mp4




