### PR TITLE
Task and request history

### DIFF
--- a/app/src/main/java/com/example/peerrequest/adapters/HistoryAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/HistoryAdapter.java
@@ -1,0 +1,4 @@
+package com.example.peerrequest.adapters;
+
+public class HistoryAdapter {
+}

--- a/app/src/main/java/com/example/peerrequest/adapters/HistoryAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/HistoryAdapter.java
@@ -1,4 +1,0 @@
-package com.example.peerrequest.adapters;
-
-public class HistoryAdapter {
-}

--- a/app/src/main/java/com/example/peerrequest/adapters/HistoryRequestAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/HistoryRequestAdapter.java
@@ -19,9 +19,6 @@ import com.example.peerrequest.models.User;
 import java.util.List;
 
 public class HistoryRequestAdapter extends RecyclerView.Adapter<HistoryRequestAdapter.HistoryViewHolder> {
-    //Idea: Instead of using different containers, I query only requests, and if the request was made by the user, put in different list
-    //else, i get the tasks from those requests and populate the view based on that
-    // when the user clicks a button, I clear the list and repopulate depending on what was clicked
     private final List<Requests> requestsList;
     Context context;
 
@@ -54,13 +51,13 @@ public class HistoryRequestAdapter extends RecyclerView.Adapter<HistoryRequestAd
         private TextView historyUsername;
         private TextView historyTaskTitle;
         private TextView historyRequestDescription;
+
         public HistoryViewHolder(@NonNull View itemView) {
             super(itemView);
             historyProfilePicture = itemView.findViewById(R.id.historyRequestProfileImage);
             historyRequestDescription = itemView.findViewById(R.id.historyRequestDescription);
             historyUsername = itemView.findViewById(R.id.historyRequestProfileName);
             historyTaskTitle = itemView.findViewById(R.id.historyRequestTitle);
-
         }
 
         public void bind(Requests request) {
@@ -69,7 +66,7 @@ public class HistoryRequestAdapter extends RecyclerView.Adapter<HistoryRequestAd
             historyTaskTitle.setText(task.getTaskTitle());
             historyUsername.setText(user.getUsername());
             historyRequestDescription.setText(request.getKeyCoverLetter());
-            Utilities.roundedImage(context,user.getProfilePicture().getUrl(),historyProfilePicture,80);
+            Utilities.roundedImage(context, user.getProfilePicture().getUrl(), historyProfilePicture, 80);
         }
     }
 }

--- a/app/src/main/java/com/example/peerrequest/adapters/HistoryRequestAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/HistoryRequestAdapter.java
@@ -1,0 +1,75 @@
+package com.example.peerrequest.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.peerrequest.R;
+import com.example.peerrequest.Utilities;
+import com.example.peerrequest.models.Requests;
+import com.example.peerrequest.models.Task;
+import com.example.peerrequest.models.User;
+
+import java.util.List;
+
+public class HistoryRequestAdapter extends RecyclerView.Adapter<HistoryRequestAdapter.HistoryViewHolder> {
+    //Idea: Instead of using different containers, I query only requests, and if the request was made by the user, put in different list
+    //else, i get the tasks from those requests and populate the view based on that
+    // when the user clicks a button, I clear the list and repopulate depending on what was clicked
+    private final List<Requests> requestsList;
+    Context context;
+
+    public HistoryRequestAdapter(Context context, List<Requests> requests) {
+        this.requestsList = requests;
+        this.context = context;
+    }
+
+    @NonNull
+    @Override
+    public HistoryViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_request_history, parent, false);
+        return new HistoryViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull HistoryViewHolder holder, int position) {
+        Requests request = requestsList.get(position);
+        holder.bind(request);
+
+    }
+
+    @Override
+    public int getItemCount() {
+        return requestsList.size();
+    }
+
+    public class HistoryViewHolder extends RecyclerView.ViewHolder {
+        private ImageView historyProfilePicture;
+        private TextView historyUsername;
+        private TextView historyTaskTitle;
+        private TextView historyRequestDescription;
+        public HistoryViewHolder(@NonNull View itemView) {
+            super(itemView);
+            historyProfilePicture = itemView.findViewById(R.id.historyRequestProfileImage);
+            historyRequestDescription = itemView.findViewById(R.id.historyRequestDescription);
+            historyUsername = itemView.findViewById(R.id.historyRequestProfileName);
+            historyTaskTitle = itemView.findViewById(R.id.historyRequestTitle);
+
+        }
+
+        public void bind(Requests request) {
+            Task task = request.getTask();
+            User user = task.getUser();
+            historyTaskTitle.setText(task.getTaskTitle());
+            historyUsername.setText(user.getUsername());
+            historyRequestDescription.setText(request.getKeyCoverLetter());
+            Utilities.roundedImage(context,user.getProfilePicture().getUrl(),historyProfilePicture,80);
+        }
+    }
+}

--- a/app/src/main/java/com/example/peerrequest/adapters/HistoryTaskAdapter.java
+++ b/app/src/main/java/com/example/peerrequest/adapters/HistoryTaskAdapter.java
@@ -1,0 +1,69 @@
+package com.example.peerrequest.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.peerrequest.R;
+import com.example.peerrequest.Utilities;
+import com.example.peerrequest.models.Task;
+import com.example.peerrequest.models.User;
+
+import java.util.List;
+
+public class HistoryTaskAdapter extends RecyclerView.Adapter<HistoryTaskAdapter.HistoryViewHolder> {
+    private final List<Task> taskList;
+    Context context;
+
+    public HistoryTaskAdapter(List<Task> tasks, Context context) {
+        this.taskList = tasks;
+        this.context = context;
+    }
+
+    @NonNull
+    @Override
+    public HistoryViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_task_history, parent, false);
+        return new HistoryViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull HistoryViewHolder holder, int position) {
+        Task task = taskList.get(position);
+        holder.bind(task);
+
+    }
+
+    @Override
+    public int getItemCount() {
+        return taskList.size();
+    }
+
+    public class HistoryViewHolder extends RecyclerView.ViewHolder {
+        private ImageView historyTaskProfilePicture;
+        private TextView historyTaskUsername;
+        private TextView historyTaskTitle;
+        private TextView historyTaskDescription;
+        public HistoryViewHolder(@NonNull View itemView) {
+            super(itemView);
+            historyTaskProfilePicture = itemView.findViewById(R.id.historyTaskProfileImage);
+            historyTaskDescription = itemView.findViewById(R.id.historyTaskDescription);
+            historyTaskUsername = itemView.findViewById(R.id.historyTaskProfileName);
+            historyTaskTitle = itemView.findViewById(R.id.historyTaskTitle);
+        }
+
+        public void bind(Task task) {
+            User user = task.getUser();
+            historyTaskTitle.setText(task.getTaskTitle());
+            historyTaskUsername.setText(user.getUsername());
+            historyTaskDescription.setText(task.getDescription());
+            Utilities.roundedImage(context,user.getProfilePicture().getUrl(),historyTaskProfilePicture,80);
+        }
+    }
+}

--- a/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
@@ -1,0 +1,35 @@
+package com.example.peerrequest.fragments;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.example.peerrequest.R;
+import com.example.peerrequest.adapters.HistoryAdapter;
+
+
+public class HistoryFragment extends Fragment {
+    protected HistoryAdapter historyAdapter;
+    private final int limit = 30;
+    private Button requestButton;
+    private Button taskButton;
+    private RecyclerView recyclerView;
+
+    public HistoryFragment() {
+        // Required empty public constructor
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_history, container, false);
+    }
+}

--- a/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
@@ -12,11 +12,15 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.peerrequest.R;
+import com.example.peerrequest.Utilities;
 import com.example.peerrequest.adapters.HistoryRequestAdapter;
 import com.example.peerrequest.adapters.HistoryTaskAdapter;
+import com.example.peerrequest.databinding.FragmentHistoryBinding;
 import com.example.peerrequest.models.Requests;
 import com.example.peerrequest.models.Task;
 import com.example.peerrequest.models.User;
@@ -29,15 +33,17 @@ import java.util.List;
 
 
 public class HistoryFragment extends Fragment {
+    private FragmentHistoryBinding binding;
     private static final int MAX_LIMIT = 40 ;
     protected HistoryRequestAdapter historyRequestAdapter;
     protected HistoryTaskAdapter historyTaskAdapter;
-    private final int limit = 30;
     private Button requestButton;
     private Button taskButton;
+    private ProgressBar progressBar;
     private RecyclerView recyclerView;
     protected List<Requests> allRequests;
     protected List<Task> allTasks;
+    private TextView clickToContinueText;
 
     public HistoryFragment() {
         // Required empty public constructor
@@ -47,8 +53,9 @@ public class HistoryFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
-        View view = inflater.inflate(R.layout.fragment_history, container, false);
+        // Binding layout to view
+        binding = FragmentHistoryBinding.inflate(inflater,container,false);
+        View view = binding.getRoot();
         return view;
 
     }
@@ -60,32 +67,33 @@ public class HistoryFragment extends Fragment {
         allTasks = new ArrayList<>();
         historyRequestAdapter = new HistoryRequestAdapter(getContext(),allRequests);
         historyTaskAdapter = new HistoryTaskAdapter(allTasks,getContext());
-        requestButton= view.findViewById(R.id.requestsHistory);
-        taskButton = view.findViewById(R.id.tasksHistory);
-        recyclerView = view.findViewById(R.id.historyRecyclerView);
-//        recyclerView.setAdapter(historyRequestAdapter);
-//        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        clickToContinueText = binding.tvDisposableText;
+        requestButton = binding.requestsHistory;
+        taskButton = binding.tasksHistory;
+        progressBar = binding.historyProgressBar;
+        recyclerView = binding.historyRecyclerView;
         requestButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Toast.makeText(getContext(), "request button clicked", Toast.LENGTH_SHORT).show();
+                clickToContinueText.setVisibility(View.INVISIBLE);
+                progressBar.setVisibility(View.VISIBLE);
                 recyclerView.setAdapter(historyRequestAdapter);
                 recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
                 queryRequests();
-
             }
         });
 
         taskButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Toast.makeText(getContext(), "task button clicked", Toast.LENGTH_SHORT).show();
+                clickToContinueText.setVisibility(View.INVISIBLE);
+                progressBar.setVisibility(View.VISIBLE);
                 recyclerView.setAdapter(historyTaskAdapter);
                 recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
                 queryTasks();
             }
         });
-//        queryRequests();
+
     }
 
     private void queryRequests(){
@@ -100,9 +108,12 @@ public class HistoryFragment extends Fragment {
                 if (e==null){
                     allRequests.clear();
                     allRequests.addAll(objects);
+                    progressBar.setVisibility(View.INVISIBLE);
                     historyRequestAdapter.notifyDataSetChanged();
                 }
-
+                else{
+                    Utilities.showAlert("Error", ""+e.getMessage(),getContext());
+                }
             }
         });
     }
@@ -118,10 +129,19 @@ public class HistoryFragment extends Fragment {
                 if (e==null){
                     allTasks.clear();
                     allTasks.addAll(objects);
+                    progressBar.setVisibility(View.INVISIBLE);
                     historyTaskAdapter.notifyDataSetChanged();
                 }
-
+                else{
+                    Utilities.showAlert("Error", ""+e.getMessage(),getContext());
+                }
             }
         });
+    }
+
+    @Override
+    public void onDestroyView() { //setting bind to null for when the view is destroyed
+        super.onDestroyView();
+        binding=null;
     }
 }

--- a/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/example/peerrequest/fragments/HistoryFragment.java
@@ -2,24 +2,42 @@ package com.example.peerrequest.fragments;
 
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.example.peerrequest.R;
-import com.example.peerrequest.adapters.HistoryAdapter;
+import com.example.peerrequest.adapters.HistoryRequestAdapter;
+import com.example.peerrequest.adapters.HistoryTaskAdapter;
+import com.example.peerrequest.models.Requests;
+import com.example.peerrequest.models.Task;
+import com.example.peerrequest.models.User;
+import com.parse.FindCallback;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class HistoryFragment extends Fragment {
-    protected HistoryAdapter historyAdapter;
+    private static final int MAX_LIMIT = 40 ;
+    protected HistoryRequestAdapter historyRequestAdapter;
+    protected HistoryTaskAdapter historyTaskAdapter;
     private final int limit = 30;
     private Button requestButton;
     private Button taskButton;
     private RecyclerView recyclerView;
+    protected List<Requests> allRequests;
+    protected List<Task> allTasks;
 
     public HistoryFragment() {
         // Required empty public constructor
@@ -30,6 +48,80 @@ public class HistoryFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_history, container, false);
+        View view = inflater.inflate(R.layout.fragment_history, container, false);
+        return view;
+
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        allRequests = new ArrayList<>();
+        allTasks = new ArrayList<>();
+        historyRequestAdapter = new HistoryRequestAdapter(getContext(),allRequests);
+        historyTaskAdapter = new HistoryTaskAdapter(allTasks,getContext());
+        requestButton= view.findViewById(R.id.requestsHistory);
+        taskButton = view.findViewById(R.id.tasksHistory);
+        recyclerView = view.findViewById(R.id.historyRecyclerView);
+//        recyclerView.setAdapter(historyRequestAdapter);
+//        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        requestButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Toast.makeText(getContext(), "request button clicked", Toast.LENGTH_SHORT).show();
+                recyclerView.setAdapter(historyRequestAdapter);
+                recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+                queryRequests();
+
+            }
+        });
+
+        taskButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Toast.makeText(getContext(), "task button clicked", Toast.LENGTH_SHORT).show();
+                recyclerView.setAdapter(historyTaskAdapter);
+                recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+                queryTasks();
+            }
+        });
+//        queryRequests();
+    }
+
+    private void queryRequests(){
+        ParseQuery<Requests> query = ParseQuery.getQuery(Requests.class);
+        query.setLimit(MAX_LIMIT);
+        query.whereEqualTo(Requests.KEY_USER, User.getCurrentUser());
+        query.include(Requests.KEY_USER);
+        query.include(Requests.KEY_TASK + "." + "UserPointer");
+        query.findInBackground(new FindCallback<Requests>() {
+            @Override
+            public void done(List<Requests> objects, ParseException e) {
+                if (e==null){
+                    allRequests.clear();
+                    allRequests.addAll(objects);
+                    historyRequestAdapter.notifyDataSetChanged();
+                }
+
+            }
+        });
+    }
+
+    private void queryTasks(){
+        ParseQuery<Task> query = ParseQuery.getQuery(Task.class);
+        query.setLimit(MAX_LIMIT);
+        query.whereEqualTo(Task.KEY_USER, User.getCurrentUser());
+        query.include(Task.KEY_USER);
+        query.findInBackground(new FindCallback<Task>() {
+            @Override
+            public void done(List<Task> objects, ParseException e) {
+                if (e==null){
+                    allTasks.clear();
+                    allTasks.addAll(objects);
+                    historyTaskAdapter.notifyDataSetChanged();
+                }
+
+            }
+        });
     }
 }

--- a/app/src/main/res/drawable/ic_history.xml
+++ b/app/src/main/res/drawable/ic_history.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#1D1D1D"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_item_task.xml
+++ b/app/src/main/res/layout/activity_item_task.xml
@@ -38,7 +38,7 @@
         <TextView
             android:id="@+id/tvTime"
             android:layout_width="wrap_content"
-            android:layout_height="16dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:text="@string/_3_days_ago"
             android:textStyle="italic"
@@ -67,8 +67,18 @@
             android:id="@+id/tvItemTaskRating"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
             android:layout_marginTop="16dp"
             android:text="TextView"
+            app:layout_constraintStart_toEndOf="@+id/textView"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Rating:"
             app:layout_constraintStart_toStartOf="@+id/tvUserName"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/activity_item_task.xml
+++ b/app/src/main/res/layout/activity_item_task.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="1dp"
@@ -12,9 +13,6 @@
     app:cardUseCompatPadding="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         tools:context=".activities.ItemTask">
@@ -64,6 +62,15 @@
             android:text="@string/hey_i_d_love_for_someone_to_go_pick_up_my_groceries_from_the_sea_to_the_seashore_and_take_it_to_ghana_if_not_possible_lorem_ipsum_lorem_lol_lol_lol"
             app:layout_constraintStart_toStartOf="@+id/tvTaskTitile"
             app:layout_constraintTop_toBottomOf="@+id/tvTaskTitile" />
+
+        <TextView
+            android:id="@+id/tvItemTaskRating"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="TextView"
+            app:layout_constraintStart_toStartOf="@+id/tvUserName"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -35,14 +35,28 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/requestsHistory" />
 
-    <FrameLayout
-        android:id="@+id/historyFrameLayout"
-        android:layout_width="412dp"
-        android:layout_height="670dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/requestsHistory"
-        app:layout_constraintVertical_bias="0.45"
-        tools:layout_editor_absoluteX="-1dp">
+    <ProgressBar
+        android:id="@+id/historyProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="272dp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.517"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/historyRecyclerView" />
 
-    </FrameLayout>
+    <TextView
+        android:id="@+id/tvDisposableText"
+        android:layout_width="227dp"
+        android:layout_height="30dp"
+        android:text="Click On A Button To Continue"
+        android:textAlignment="center"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/historyRecyclerView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/historyRecyclerView" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -27,9 +27,22 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/historyRecyclerView"
-        android:layout_width="408dp"
-        android:layout_height="666dp"
+        android:layout_width="373dp"
+        android:layout_height="634dp"
+        android:layout_marginTop="4dp"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.578"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/requestsHistory" />
+
+    <FrameLayout
+        android:id="@+id/historyFrameLayout"
+        android:layout_width="412dp"
+        android:layout_height="670dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/requestsHistory"
+        app:layout_constraintVertical_bias="0.45"
+        tools:layout_editor_absoluteX="-1dp">
+
+    </FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/tasksHistory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="60dp"
+        android:layout_marginTop="16dp"
+        android:text="tasks"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/requestsHistory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="88dp"
+        android:layout_marginTop="16dp"
+        android:text="requests"
+        app:layout_constraintStart_toEndOf="@+id/tasksHistory"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/historyRecyclerView"
+        android:layout_width="408dp"
+        android:layout_height="666dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/requestsHistory" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_request_history.xml
+++ b/app/src/main/res/layout/item_request_history.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/historyRequestProfileImage"
+        android:layout_width="97dp"
+        android:layout_height="69dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/historyRequestProfileName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:text="TextView"
+        android:textSize="16sp"
+        android:textStyle="bold|italic"
+        app:layout_constraintStart_toEndOf="@+id/historyRequestProfileImage"
+        app:layout_constraintTop_toTopOf="@+id/historyRequestProfileImage" />
+
+    <TextView
+        android:id="@+id/historyRequestTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:layout_marginBottom="28dp"
+        android:text="TextView"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@+id/historyRequestProfileImage"
+        app:layout_constraintStart_toStartOf="@+id/historyRequestProfileName"
+        app:layout_constraintTop_toBottomOf="@+id/historyRequestProfileName"
+        app:layout_constraintVertical_bias="0.0" />
+
+
+    <TextView
+        android:id="@+id/historyRequestDescription"
+        android:layout_width="244dp"
+        android:layout_height="62dp"
+        android:layout_marginStart="144dp"
+        android:text="TextView"
+        app:layout_constraintStart_toStartOf="@+id/historyRequestProfileImage"
+        app:layout_constraintTop_toBottomOf="@+id/historyRequestTitle" />
+
+    <ImageView
+        android:id="@+id/imageView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:background="@android:color/holo_green_dark"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/historyRequestDescription"
+        app:layout_constraintTop_toTopOf="@+id/historyRequestDescription"
+        app:layout_constraintVertical_bias="0.026"
+        app:srcCompat="@drawable/ic_arrow" />
+
+    <TextView
+        android:id="@+id/historyTaskNumberOfRequests"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Pending"
+        app:layout_constraintStart_toStartOf="@+id/historyRequestProfileImage"
+        app:layout_constraintTop_toBottomOf="@+id/historyRequestProfileImage" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_task_history.xml
+++ b/app/src/main/res/layout/item_task_history.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/historyTaskProfileImage"
+        android:layout_width="97dp"
+        android:layout_height="69dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/historyTaskProfileName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:text="TextView"
+        android:textSize="16sp"
+        android:textStyle="bold|italic"
+        app:layout_constraintStart_toEndOf="@+id/historyTaskProfileImage"
+        app:layout_constraintTop_toTopOf="@+id/historyTaskProfileImage" />
+
+    <TextView
+        android:id="@+id/historyTaskTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:layout_marginBottom="28dp"
+        android:text="TextView"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@+id/historyTaskProfileImage"
+        app:layout_constraintStart_toStartOf="@+id/historyTaskProfileName"
+        app:layout_constraintTop_toBottomOf="@+id/historyTaskProfileName"
+        app:layout_constraintVertical_bias="0.0" />
+
+
+    <TextView
+        android:id="@+id/historyTaskDescription"
+        android:layout_width="244dp"
+        android:layout_height="wrap_content"
+        android:text="TextView"
+        app:layout_constraintStart_toStartOf="@+id/historyTaskTitle"
+        app:layout_constraintTop_toBottomOf="@+id/historyTaskTitle" />
+
+    <TextView
+        android:id="@+id/historyTaskNumberOfRequests"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:text="6 requests"
+        app:layout_constraintStart_toStartOf="@+id/historyTaskProfileImage"
+        app:layout_constraintTop_toBottomOf="@+id/historyTaskProfileImage" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -13,6 +13,11 @@
         android:title="Search"
         app:showAsAction="always" />
     <item
+        android:id="@+id/action_History"
+        android:icon="@drawable/ic_history"
+        android:title="History"
+        app:showAsAction="always" />
+    <item
         android:icon="@drawable/ic_person"
         android:id="@+id/action_Profile"
         android:title="Profile"


### PR DESCRIPTION
#56 In this Pull Request, I implemented a Task and Request History fragment (as suggested by Omar)
- I created an extra menu Item on the bottom navigation bar where the user can view previous requests made to complete tasks and tasks he/she has listed
-To achieve this, I created a couple of layouts, a single fragment containing a single recycler view and two adapters
- I was thinking, It'd probably be extensive to create two separate fragments that I'd swap within a frame layout so Instead, Whenever either the task history or request history button is clicked, i swap the adapter populating the single recycler view depending on the button and then make a query. ( I was surprised this worked )
- I'd probably have to re-design my User profile fragment since the task history is now also shown in the history page
- I also implemented View Binding for the first time ( as an alternative to several findViewsByID suggested by Garrett)

https://user-images.githubusercontent.com/90366540/179382687-d33c9bb4-6464-448a-9010-5a64811f5f22.mp4


