### PR TITLE
Fixed Minor Bug where the keyboard covered the UI while typing in Chat

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         tools:targetApi="31">
         <activity
             android:name=".activities.ChatActivity"
+            android:windowSoftInputMode="adjustPan"
             android:exported="false" />
 
         <meta-data


### PR DESCRIPTION
-In this PR, i fixed the minor bug where the keyboard covered the UI while typing
- To fix this, I included the adjustPan option in the activity section of the chatActivity in the AndroidManifest
#60 

https://user-images.githubusercontent.com/90366540/179382903-50537053-2987-4f16-b78a-7b256b89c18a.mp4


